### PR TITLE
PowerADSR Refactor

### DIFF
--- a/PowerADSR/PowerADSR.cpp
+++ b/PowerADSR/PowerADSR.cpp
@@ -398,7 +398,7 @@ CK_DLL_QUERY( PowerADSR)
     QUERY->setname(QUERY, "PowerADSR");
 
     QUERY->begin_class(QUERY, "PowerADSR", "Envelope");
-    QUERY->doc_class(QUERY, "ADSR envelope that uses a power function to create curved envelope phases.");
+    QUERY->doc_class(QUERY, "ADSR envelope that uses a power function to create curved envelope phases. In general, curves under 1.0 are sharp, while curves over 1.0 are soft.");
 
     QUERY->add_ctor(QUERY, poweradsr_ctor);
     QUERY->add_dtor(QUERY, poweradsr_dtor);

--- a/PowerADSR/PowerADSR.cpp
+++ b/PowerADSR/PowerADSR.cpp
@@ -73,17 +73,17 @@ public:
     // constructor
     PowerADSR( t_CKFLOAT fs)
     {
-        // stage durations
-        m_attackDuration = 0.0;
-        m_decayDuration = 0.0;
-        m_releaseDuration = 0.0;
+        // stage durations, set to 1::second
+        m_attackDuration = fs;
+        m_decayDuration = fs;
+        m_releaseDuration = fs;
 
         m_sustainLevel = 0.5;
 
         // for one less calculation per tick
-        m_inverseAttackDuration = 0.0;
-        m_inverseDecayDuration = 0.0;
-        m_inverseReleaseDuration = 0.0;
+        m_inverseAttackDuration = 1.0/fs;
+        m_inverseDecayDuration = 1.0/fs;
+        m_inverseReleaseDuration = 1.0/fs;
 
         // values
         m_linearValue = 0.0;

--- a/PowerADSR/PowerADSR.cpp
+++ b/PowerADSR/PowerADSR.cpp
@@ -1,23 +1,20 @@
-
 /*-----------------------------------------------------------------------------
  Entaro!
 
- ChucK PowerADSR extends Envelope.
+ An ADSR Envelope that allows for power-shaped stages.
 
- An ADSR Envelope that allows for power-shaped envelope phases.
-
- Copyright (c) 2015 Eric Heep. All rights reserved.
+ Copyright (c) 2017 Eric Heep. All rights reserved.
 
  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation; either version 2 of the License, or
  (at your option) any later version.
- 
+
  This program is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with this program; if not, write to the Free Software
  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
@@ -34,22 +31,41 @@
 CK_DLL_CTOR(poweradsr_ctor);
 CK_DLL_DTOR(poweradsr_dtor);
 
+// setters
 CK_DLL_MFUN(poweradsr_setKeyOn);
 CK_DLL_MFUN(poweradsr_setKeyOff);
 
-CK_DLL_MFUN(poweradsr_setAll);
-CK_DLL_MFUN(poweradsr_setAttack);
-CK_DLL_MFUN(poweradsr_setDecay);
-CK_DLL_MFUN(poweradsr_setSustain);
-CK_DLL_MFUN(poweradsr_setRelease);
+CK_DLL_MFUN(poweradsr_setAllTimes);
+CK_DLL_MFUN(poweradsr_setAttackTime);
+CK_DLL_MFUN(poweradsr_setDecayTime);
+CK_DLL_MFUN(poweradsr_setReleaseTime);
 
 CK_DLL_MFUN(poweradsr_setAllCurves);
 CK_DLL_MFUN(poweradsr_setAttackCurve);
 CK_DLL_MFUN(poweradsr_setDecayCurve);
 CK_DLL_MFUN(poweradsr_setReleaseCurve);
 
+CK_DLL_MFUN(poweradsr_setSustainLevel);
+
+// getters
+CK_DLL_MFUN(poweradsr_getSustainLevel);
+
+CK_DLL_MFUN(poweradsr_getAttackTime);
+CK_DLL_MFUN(poweradsr_getDecayTime);
+CK_DLL_MFUN(poweradsr_getReleaseTime);
+
+CK_DLL_MFUN(poweradsr_getAttackCurve);
+CK_DLL_MFUN(poweradsr_getDecayCurve);
+CK_DLL_MFUN(poweradsr_getReleaseCurve);
+
+CK_DLL_MFUN(poweradsr_getValue);
+CK_DLL_MFUN(poweradsr_getState);
+
+// tick
 CK_DLL_TICK(poweradsr_tick);
+
 t_CKINT poweradsr_data_offset = 0;
+
 
 class PowerADSR
 {
@@ -57,157 +73,183 @@ public:
     // constructor
     PowerADSR( t_CKFLOAT fs)
     {
-        m_keyOn = 0;
-        m_keyOff = 0;
-
-        // stage counters
-        m_attackCount = 0;
-        m_decayCount = 0;
-        m_releaseCount = 0;
-
         // stage durations
         m_attackDuration = 0.0;
         m_decayDuration = 0.0;
         m_releaseDuration = 0.0;
 
-        // levels
-        m_sustainLevel = 1.0;
-        m_currentLevel = 0.0;
-        m_keyOnLevel = 0.0;
-        m_keyOffLevel = 0.0;
+        // for less calculations
+        m_inverseAttackDuration = 0.0;
+        m_inverseDecayDuration = 0.0;
+        m_inverseReleaseDuration = 0.0;
 
-        // initializes to linear envelopes 
+        // values
+        m_linearValue = 0.0;
+        m_powerValue = 0.0;
+        m_offsetValue = 0.0;
+
+        // sample multipler
+        m_value = 0.0;
+
+        m_target = 1.0;
+        m_sustainLevel = 0.5;
+
+        // initializes to linear envelopes
         m_attackCurve = 1.0;
         m_decayCurve = 1.0;
         m_releaseCurve = 1.0;
+
+        m_scalarValue = 1.0;
+
+        m_curve = 1.0;
+        m_inverseDuration = 0.0;
+
+        m_state = DONE;
     }
 
     // for Chugins extending UGen
     SAMPLE tick( SAMPLE in )
     {
-        if(m_keyOn == 1) 
+        switch(m_state)
         {
-            if (m_attackCount < m_attackDuration) {
-                m_attackCount++;
-                m_currentLevel = pow(m_attackCount/m_attackDuration, m_attackCurve) * (1.0 - m_keyOnLevel) + m_keyOnLevel;
 
-                return in * m_currentLevel;
-            }
-            if (m_decayCount < m_decayDuration) {
-                m_decayCount++; 
-                m_currentLevel = (1.0 - pow(m_decayCount/m_decayDuration, m_decayCurve)) * (1.0 - m_sustainLevel) + m_sustainLevel;
+        case ATTACK:
+            m_sampleCount++;
+            if (m_sampleCount >= m_attackDuration) {
+                m_sampleCount = m_decayDuration;
+                m_inverseDuration = m_inverseDecayDuration;
+                m_curve = m_decayCurve;
+                m_offsetValue = m_sustainLevel;
+                m_scalarValue = m_target - m_sustainLevel;
 
-                return in * m_currentLevel;
+                m_state = DECAY;
             }
-            else {
-                return in * m_currentLevel;
+            break;
+
+        case DECAY:
+            m_sampleCount--;
+            if (m_sampleCount <= 0.0) {
+                m_sampleCount = m_releaseDuration;
+                m_inverseDuration = m_inverseReleaseDuration;
+                m_curve = m_releaseCurve;
+                m_offsetValue = 0.0;
+                m_scalarValue = m_sustainLevel;
+
+                m_state = SUSTAIN;
             }
+            break;
+
+        case SUSTAIN:
+            break;
+
+        case RELEASE:
+            m_sampleCount--;
+            if (m_sampleCount <= 0.0) {
+                m_linearValue = 0.0;
+                m_scalarValue = 1.0;
+                m_state = DONE;
+            }
+            break;
+
+        case DONE:
+            break;
         }
 
-        if(m_keyOff == 1) 
-        {
-            if (m_releaseCount < m_releaseDuration) {
-                m_releaseCount++;
-                m_currentLevel = ((1.0 - pow(m_releaseCount/m_releaseDuration, m_releaseCurve)) * m_keyOffLevel); 
+        // linear scaling derived from duration
+        m_linearValue = m_sampleCount * m_inverseDuration;
 
-                return in * m_currentLevel; 
-            }
-            else {
-                m_keyOff = 0;
-            }
-        }
-        return 0.0;
+        // power curve
+        m_powerValue = pow(m_linearValue, m_curve);
+
+        // added calculations for stage changes
+        m_value = m_powerValue * m_scalarValue + m_offsetValue;
+
+        return in * m_value;
     }
 
     // keyOn stuff
     int setKeyOn()
     {
-        m_keyOnLevel = m_currentLevel;
+        m_sampleCount = 0.0;
+        m_inverseDuration = m_inverseAttackDuration;
+        m_curve = m_attackCurve;
+        m_offsetValue = m_value;
+        m_scalarValue = m_target - m_value;
 
-        m_attackCount = 0;
-        m_decayCount = 0;
-        m_keyOn = 1;
-        m_keyOff = 0;
-
-        return m_keyOn;
+        m_state = ATTACK;
+        return 1;
     }
 
     int setKeyOn( t_CKINT )
     {
-        m_keyOnLevel = m_currentLevel;
+        m_sampleCount = 0.0;
+        m_inverseDuration = m_inverseAttackDuration;
+        m_curve = m_attackCurve;
+        m_offsetValue = m_value;
+        m_scalarValue = m_target - m_value;
 
-        m_attackCount = 0;
-        m_decayCount = 0;
-        m_keyOn = 1;
-        m_keyOff = 0;
-
-        return m_keyOn;
+        m_state = ATTACK;
+        return 1;
     }
 
     // keyOff stuff
-    int setKeyOff() 
+    int setKeyOff()
     {
-        m_keyOffLevel = m_currentLevel;
-        m_releaseCount = 0;
+        m_sampleCount = m_releaseDuration;
+        m_inverseDuration = m_inverseReleaseDuration;
+        m_curve = m_releaseCurve;
+        m_offsetValue = 0.0;
+        m_scalarValue = m_value;
 
-        m_keyOn = 0;
-        m_keyOff = 1;
-
-        return m_keyOff;
+        m_state = RELEASE;
+        return 0;
     }
 
     int setKeyOff( t_CKINT )
     {
-        m_keyOffLevel = m_currentLevel;
-        m_releaseCount = 0;
+        m_sampleCount = m_releaseDuration;
+        m_inverseDuration = m_inverseReleaseDuration;
+        m_curve = m_releaseCurve;
+        m_offsetValue = 0.0;
+        m_scalarValue = m_value;
 
-        m_keyOn = 0;
-        m_keyOff = 1;
-
-        return m_keyOn;
+        m_state = RELEASE;
+        return 0;
     }
 
-    // set all durations
-    void setAll( t_CKDUR a, t_CKDUR d, t_CKFLOAT s, t_CKDUR r ) {
-        setAttack(a);
-        setDecay(d);
-        setSustain(s);
-        setRelease(r);
+    // set all durations and sustain level
+    void setAll( t_CKDUR a, t_CKDUR d, t_CKFLOAT s, t_CKDUR r )
+    {
+        setAttackTime(a);
+        setDecayTime(d);
+        setSustainLevel(s);
+        setReleaseTime(r);
     }
 
-    float setAttack( t_CKDUR a ) 
+    float setAttackTime( t_CKDUR a )
     {
         m_attackDuration = (float)a;
-
-        m_keyOnLevel = m_currentLevel;
-        m_attackCount = 0;
-
+        m_inverseAttackDuration = 1.0 / m_attackDuration;
         return a;
     }
 
-    float setDecay( t_CKDUR d ) 
+    float setDecayTime( t_CKDUR d )
     {
         m_decayDuration = (float)d;
-
-        m_sustainLevel = m_currentLevel;
-        m_decayCount = 0;
-        
+        m_inverseDecayDuration = 1.0 / m_decayDuration;
         return d;
     }
 
-    float setSustain( t_CKFLOAT s ) 
+    float setSustainLevel( t_CKFLOAT s )
     {
         m_sustainLevel = s;
         return s;
     }
 
-    float setRelease( t_CKDUR r ) 
+    float setReleaseTime( t_CKDUR r )
     {
         m_releaseDuration = (float)r;
-
-        m_keyOffLevel = m_currentLevel;
-        m_releaseCount = 0;
-
+        m_inverseReleaseDuration = 1.0 / m_releaseDuration;
         return r;
     }
 
@@ -218,73 +260,136 @@ public:
         setReleaseCurve(r);
     }
 
-    float setAttackCurve( t_CKFLOAT ac) 
+    float setAttackCurve( t_CKFLOAT a)
     {
-        m_attackCurve = ac;
-
-        m_keyOnLevel = m_currentLevel;
-        m_attackCount = 0;
-
-        return ac;
+        m_attackCurve = a;
+        return a;
     }
 
-    float setDecayCurve( t_CKFLOAT dc) 
+    float setDecayCurve( t_CKFLOAT d)
     {
-        m_decayCurve = dc;
-
-        m_sustainLevel = m_currentLevel;
-        m_decayCount = 0;
-
-        return dc;
+        m_decayCurve = d;
+        return d;
     }
 
-    float setReleaseCurve( t_CKFLOAT rc) 
+    float setReleaseCurve( t_CKFLOAT r)
     {
-        m_releaseCurve = rc;
-
-        m_keyOffLevel = m_currentLevel;
-        m_releaseCount = 0;
-
-        return rc;
+        m_releaseCurve = r;
+        return r;
     }
+
+    void setTarget( t_CKFLOAT t)
+    {
+      m_target = t;
+
+      if (m_powerValue < m_target) {
+        setSustainLevel(m_target);
+      }
+      if (m_powerValue > m_target) {
+        setSustainLevel(m_target);
+      }
+    }
+
+    float getAttackTime()
+    {
+        return m_attackDuration;
+    }
+
+    float getDecayTime()
+    {
+        return m_decayDuration;
+    }
+
+    float getSustainLevel()
+    {
+        return m_sustainLevel;
+    }
+
+    float getReleaseTime()
+    {
+        return m_releaseDuration;
+    }
+
+    float getAttackCurve()
+    {
+        return m_attackCurve;
+    }
+
+    float getDecayCurve()
+    {
+        return m_decayCurve;
+    }
+
+    float getReleaseCurve()
+    {
+        return m_releaseCurve;
+    }
+
+    float getValue()
+    {
+        return m_value;
+    }
+
+    int getState()
+    {
+        return m_state;
+    }
+
 
 private:
-    int m_keyOn;
-    int m_keyOff;
-
-    // sample counters 
-    int m_attackCount;
-    int m_decayCount;
-    int m_releaseCount;
 
     // durations
     float m_attackDuration;
     float m_decayDuration;
     float m_releaseDuration;
 
+    float m_inverseAttackDuration;
+    float m_inverseDecayDuration;
+    float m_inverseReleaseDuration;
+
+    float m_inverseDuration;
+
     // levels
+    float m_linearValue;
+    float m_powerValue;
+    float m_offsetValue;
+    float m_value;
+
+    // time tracking
+    float m_sampleCount;
+    float m_scalarValue;
+
+    float m_target;
     float m_sustainLevel;
-    float m_currentLevel;
-    float m_keyOnLevel;
-    float m_keyOffLevel;
 
     // curves
+    float m_curve;
     float m_attackCurve;
     float m_decayCurve;
     float m_releaseCurve;
+
+    enum States {
+        DONE = 0,
+        ATTACK,
+        DECAY,
+        SUSTAIN,
+        RELEASE,
+    };
+
+    States m_state;
 };
 
 
-CK_DLL_QUERY( PowerADSR )
+CK_DLL_QUERY( PowerADSR)
 {
     QUERY->setname(QUERY, "PowerADSR");
-    
+
     QUERY->begin_class(QUERY, "PowerADSR", "Envelope");
     QUERY->doc_class(QUERY, "ADSR envelope that uses a power function to create curved envelope phases, extends Envelope.");
-    
+
     QUERY->add_ctor(QUERY, poweradsr_ctor);
     QUERY->add_dtor(QUERY, poweradsr_dtor);
-    
+
     QUERY->add_ugen_func(QUERY, poweradsr_tick, NULL, 1, 1);
 
     QUERY->add_mfun(QUERY, poweradsr_setKeyOn, "int", "keyOn");
@@ -300,30 +405,42 @@ CK_DLL_QUERY( PowerADSR )
     QUERY->add_mfun(QUERY, poweradsr_setKeyOff, "int", "keyOff");
     QUERY->add_arg(QUERY, "int", "keyOff");
     QUERY->doc_func(QUERY, "Begins the release phase of the envelope. ");
-    
-    QUERY->add_mfun(QUERY, poweradsr_setAll, "void", "set");
+
+    QUERY->add_mfun(QUERY, poweradsr_setAllTimes, "void", "set");
     QUERY->add_arg(QUERY, "dur", "attackDuration");
     QUERY->add_arg(QUERY, "dur", "decayDuration");
     QUERY->add_arg(QUERY, "float", "sustainLevel");
     QUERY->add_arg(QUERY, "dur", "releaseDuration");
     QUERY->doc_func(QUERY, "Sets duration of the attack, decay, and release phases; as well as the sustain level (ADSR order). ");
 
-    QUERY->add_mfun(QUERY, poweradsr_setAttack, "dur", "attack");
+    QUERY->add_mfun(QUERY, poweradsr_setAttackTime, "dur", "attack");
     QUERY->add_arg(QUERY, "dur", "attackDuration");
     QUERY->doc_func(QUERY, "Sets duration of the attack phase. ");
 
-    QUERY->add_mfun(QUERY, poweradsr_setDecay, "dur", "decay");
+    QUERY->add_mfun(QUERY, poweradsr_setAttackTime, "dur", "attackTime");
+    QUERY->add_arg(QUERY, "dur", "attackDuration");
+    QUERY->doc_func(QUERY, "Sets duration of the attack phase. ");
+
+    QUERY->add_mfun(QUERY, poweradsr_setDecayTime, "dur", "decay");
     QUERY->add_arg(QUERY, "dur", "decayDuration");
     QUERY->doc_func(QUERY, "Sets duration of the decay phase. ");
- 
-    QUERY->add_mfun(QUERY, poweradsr_setSustain, "float", "sustain");
+
+    QUERY->add_mfun(QUERY, poweradsr_setDecayTime, "dur", "decayTime");
+    QUERY->add_arg(QUERY, "dur", "decayDuration");
+    QUERY->doc_func(QUERY, "Sets duration of the decay phase. ");
+
+    QUERY->add_mfun(QUERY, poweradsr_setSustainLevel, "float", "sustainLevel");
     QUERY->add_arg(QUERY, "float", "sustainLevel");
     QUERY->doc_func(QUERY, "Sets sustain level. ");
 
-    QUERY->add_mfun(QUERY, poweradsr_setRelease, "dur", "release");
+    QUERY->add_mfun(QUERY, poweradsr_setReleaseTime, "dur", "release");
     QUERY->add_arg(QUERY, "dur", "releaseDuration");
     QUERY->doc_func(QUERY, "Sets duration of the release phase. ");
- 
+
+    QUERY->add_mfun(QUERY, poweradsr_setReleaseTime, "dur", "releaseTime");
+    QUERY->add_arg(QUERY, "dur", "releaseDuration");
+    QUERY->doc_func(QUERY, "Sets duration of the release phase. ");
+
     QUERY->add_mfun(QUERY, poweradsr_setAllCurves, "void", "setCurves");
     QUERY->add_arg(QUERY, "float", "attackCurve");
     QUERY->add_arg(QUERY, "float", "decayCurve");
@@ -342,7 +459,34 @@ CK_DLL_QUERY( PowerADSR )
     QUERY->add_arg(QUERY, "float", "releaseCurve");
     QUERY->doc_func(QUERY, "Sets envelope curve of the release phase. ");
 
-    // this reserves a variable in the ChucK internal class to store 
+    QUERY->add_mfun(QUERY, poweradsr_getSustainLevel, "float", "sustainLevel");
+    QUERY->doc_func(QUERY, "Gets sustain level.");
+
+    QUERY->add_mfun(QUERY, poweradsr_getAttackTime, "dur", "attackTime");
+    QUERY->doc_func(QUERY, "Gets the attack duration.");
+
+    QUERY->add_mfun(QUERY, poweradsr_getDecayTime, "dur", "decayTime");
+    QUERY->doc_func(QUERY, "Gets the decay duration.");
+
+    QUERY->add_mfun(QUERY, poweradsr_getReleaseTime, "dur", "releaseTime");
+    QUERY->doc_func(QUERY, "Gets the release duration. ");
+
+    QUERY->add_mfun(QUERY, poweradsr_getAttackTime, "float", "attackCurve");
+    QUERY->doc_func(QUERY, "Gets the attack curve.");
+
+    QUERY->add_mfun(QUERY, poweradsr_getDecayTime, "float", "decayCurve");
+    QUERY->doc_func(QUERY, "Gets the decay curve.");
+
+    QUERY->add_mfun(QUERY, poweradsr_getReleaseTime, "float", "releaseCurve");
+    QUERY->doc_func(QUERY, "Gets the release curve.");
+
+    QUERY->add_mfun(QUERY, poweradsr_getValue, "float", "value");
+    QUERY->doc_func(QUERY, "Gets current envelope value.");
+
+    QUERY->add_mfun(QUERY, poweradsr_getState, "int", "state");
+    QUERY->doc_func(QUERY, "Gets current state. ");
+
+    // this reserves a variable in the ChucK internal class to store
     // referene to the c++ class we defined above
     poweradsr_data_offset = QUERY->add_mvar(QUERY, "int", "@ee_data", false);
 
@@ -360,12 +504,12 @@ CK_DLL_CTOR(poweradsr_ctor)
 {
     // get the offset where we'll store our internal c++ class pointer
     OBJ_MEMBER_INT(SELF, poweradsr_data_offset) = 0;
-    
+
     // instantiate our internal c++ class representation
-    PowerADSR * bcdata = new PowerADSR(API->vm->get_srate());
-    
+    PowerADSR * padsr_obj = new PowerADSR(API->vm->get_srate());
+
     // store the pointer in the ChucK object member
-    OBJ_MEMBER_INT(SELF, poweradsr_data_offset) = (t_CKINT) bcdata;
+    OBJ_MEMBER_INT(SELF, poweradsr_data_offset) = (t_CKINT) padsr_obj;
 }
 
 
@@ -373,14 +517,14 @@ CK_DLL_CTOR(poweradsr_ctor)
 CK_DLL_DTOR(poweradsr_dtor)
 {
     // get our c++ class pointer
-    PowerADSR * bcdata = (PowerADSR *) OBJ_MEMBER_INT(SELF, poweradsr_data_offset);
+    PowerADSR * padsr_obj = (PowerADSR *) OBJ_MEMBER_INT(SELF, poweradsr_data_offset);
     // check it
-    if( bcdata )
+    if( padsr_obj )
     {
         // clean up
-        delete bcdata;
+        delete padsr_obj;
         OBJ_MEMBER_INT(SELF, poweradsr_data_offset) = 0;
-        bcdata = NULL;
+        padsr_obj = NULL;
     }
 }
 
@@ -389,10 +533,10 @@ CK_DLL_DTOR(poweradsr_dtor)
 CK_DLL_TICK(poweradsr_tick)
 {
     // get our c++ class pointer
-    PowerADSR * c = (PowerADSR *) OBJ_MEMBER_INT(SELF, poweradsr_data_offset);
- 
+    PowerADSR * padsr_obj = (PowerADSR *) OBJ_MEMBER_INT(SELF, poweradsr_data_offset);
+
     // invoke our tick function; store in the magical out variable
-    if(c) *out = c->tick(in);
+    if(padsr_obj) *out = padsr_obj->tick(in);
 
     // yes
     return TRUE;
@@ -400,76 +544,129 @@ CK_DLL_TICK(poweradsr_tick)
 
 CK_DLL_MFUN(poweradsr_setKeyOn)
 {
-    PowerADSR * bcdata = (PowerADSR *) OBJ_MEMBER_INT(SELF, poweradsr_data_offset);
-    bcdata->setKeyOn(1);
+    PowerADSR * padsr_obj = (PowerADSR *) OBJ_MEMBER_INT(SELF, poweradsr_data_offset);
+    padsr_obj->setKeyOn(1);
     RETURN->v_int = 1;
 }
 
 CK_DLL_MFUN(poweradsr_setKeyOff)
 {
-    PowerADSR * bcdata = (PowerADSR *) OBJ_MEMBER_INT(SELF, poweradsr_data_offset);
-    bcdata->setKeyOff(1);
+    PowerADSR * padsr_obj = (PowerADSR *) OBJ_MEMBER_INT(SELF, poweradsr_data_offset);
+    padsr_obj->setKeyOff(1);
     RETURN->v_int = 1;
 }
 
-CK_DLL_MFUN(poweradsr_setAttack)
+CK_DLL_MFUN(poweradsr_setAttackTime)
 {
-    PowerADSR * bcdata = (PowerADSR *) OBJ_MEMBER_INT(SELF, poweradsr_data_offset);
-    RETURN->v_dur = bcdata->setAttack(GET_NEXT_DUR(ARGS));
+    PowerADSR * padsr_obj = (PowerADSR *) OBJ_MEMBER_INT(SELF, poweradsr_data_offset);
+    RETURN->v_dur = padsr_obj->setAttackTime(GET_NEXT_DUR(ARGS));
 }
 
-CK_DLL_MFUN(poweradsr_setDecay)
+CK_DLL_MFUN(poweradsr_setDecayTime)
 {
-    PowerADSR * bcdata = (PowerADSR *) OBJ_MEMBER_INT(SELF, poweradsr_data_offset);
-    RETURN->v_dur = bcdata->setDecay(GET_NEXT_DUR(ARGS));
+    PowerADSR * padsr_obj = (PowerADSR *) OBJ_MEMBER_INT(SELF, poweradsr_data_offset);
+    RETURN->v_dur = padsr_obj->setDecayTime(GET_NEXT_DUR(ARGS));
 }
 
-CK_DLL_MFUN(poweradsr_setAll)
+CK_DLL_MFUN(poweradsr_setAllTimes)
 {
-    PowerADSR * bcdata = (PowerADSR *) OBJ_MEMBER_INT(SELF, poweradsr_data_offset);
+    PowerADSR * padsr_obj = (PowerADSR *) OBJ_MEMBER_INT(SELF, poweradsr_data_offset);
     t_CKDUR aDur = GET_NEXT_DUR(ARGS);
     t_CKDUR dDur = GET_NEXT_DUR(ARGS);
     t_CKFLOAT sLvl = GET_NEXT_FLOAT(ARGS);
     t_CKDUR rDur = GET_NEXT_DUR(ARGS);
-    bcdata->setAll(aDur, dDur, sLvl, rDur);
+    padsr_obj->setAll(aDur, dDur, sLvl, rDur);
 }
 
-CK_DLL_MFUN(poweradsr_setSustain)
+CK_DLL_MFUN(poweradsr_setSustainLevel)
 {
-    PowerADSR * bcdata = (PowerADSR *) OBJ_MEMBER_INT(SELF, poweradsr_data_offset);
-    RETURN->v_float = bcdata->setSustain(GET_NEXT_FLOAT(ARGS));
+    PowerADSR * padsr_obj = (PowerADSR *) OBJ_MEMBER_INT(SELF, poweradsr_data_offset);
+    RETURN->v_float = padsr_obj->setSustainLevel(GET_NEXT_FLOAT(ARGS));
 }
 
-CK_DLL_MFUN(poweradsr_setRelease)
+CK_DLL_MFUN(poweradsr_setReleaseTime)
 {
-    PowerADSR * bcdata = (PowerADSR *) OBJ_MEMBER_INT(SELF, poweradsr_data_offset);
-    RETURN->v_dur = bcdata->setRelease(GET_NEXT_DUR(ARGS));
+    PowerADSR * padsr_obj = (PowerADSR *) OBJ_MEMBER_INT(SELF, poweradsr_data_offset);
+    RETURN->v_dur = padsr_obj->setReleaseTime(GET_NEXT_DUR(ARGS));
 }
 
 CK_DLL_MFUN(poweradsr_setAllCurves)
 {
-    PowerADSR * bcdata = (PowerADSR *) OBJ_MEMBER_INT(SELF, poweradsr_data_offset);
+    PowerADSR * padsr_obj = (PowerADSR *) OBJ_MEMBER_INT(SELF, poweradsr_data_offset);
     t_CKFLOAT aCurv = GET_NEXT_FLOAT(ARGS);
     t_CKFLOAT dCurv = GET_NEXT_FLOAT(ARGS);
     t_CKFLOAT rCurv = GET_NEXT_FLOAT(ARGS);
-    bcdata->setAllCurves(aCurv, dCurv, rCurv);
+    padsr_obj->setAllCurves(aCurv, dCurv, rCurv);
 }
 
 CK_DLL_MFUN(poweradsr_setAttackCurve)
 {
-    PowerADSR * bcdata = (PowerADSR *) OBJ_MEMBER_INT(SELF, poweradsr_data_offset);
-    RETURN->v_float = bcdata->setAttackCurve(GET_NEXT_FLOAT(ARGS));
+    PowerADSR * padsr_obj = (PowerADSR *) OBJ_MEMBER_INT(SELF, poweradsr_data_offset);
+    RETURN->v_float = padsr_obj->setAttackCurve(GET_NEXT_FLOAT(ARGS));
 }
 
 CK_DLL_MFUN(poweradsr_setDecayCurve)
 {
-    PowerADSR * bcdata = (PowerADSR *) OBJ_MEMBER_INT(SELF, poweradsr_data_offset);
-    RETURN->v_float = bcdata->setDecayCurve(GET_NEXT_FLOAT(ARGS));
+    PowerADSR * padsr_obj = (PowerADSR *) OBJ_MEMBER_INT(SELF, poweradsr_data_offset);
+    RETURN->v_float = padsr_obj->setDecayCurve(GET_NEXT_FLOAT(ARGS));
 }
 
 CK_DLL_MFUN(poweradsr_setReleaseCurve)
 {
-    PowerADSR * bcdata = (PowerADSR *) OBJ_MEMBER_INT(SELF, poweradsr_data_offset);
-    RETURN->v_float = bcdata->setReleaseCurve(GET_NEXT_FLOAT(ARGS));
+    PowerADSR * padsr_obj = (PowerADSR *) OBJ_MEMBER_INT(SELF, poweradsr_data_offset);
+    RETURN->v_float = padsr_obj->setReleaseCurve(GET_NEXT_FLOAT(ARGS));
 }
 
+CK_DLL_MFUN(poweradsr_getSustainLevel)
+{
+    PowerADSR * padsr_obj = (PowerADSR *) OBJ_MEMBER_INT(SELF, poweradsr_data_offset);
+    RETURN->v_float = padsr_obj->getSustainLevel();
+}
+
+CK_DLL_MFUN(poweradsr_getAttackTime)
+{
+    PowerADSR * padsr_obj = (PowerADSR *) OBJ_MEMBER_INT(SELF, poweradsr_data_offset);
+    RETURN->v_dur = padsr_obj->getAttackTime();
+}
+
+CK_DLL_MFUN(poweradsr_getDecayTime)
+{
+    PowerADSR * padsr_obj = (PowerADSR *) OBJ_MEMBER_INT(SELF, poweradsr_data_offset);
+    RETURN->v_dur = padsr_obj->getDecayTime();
+}
+
+CK_DLL_MFUN(poweradsr_getReleaseTime)
+{
+    PowerADSR * padsr_obj = (PowerADSR *) OBJ_MEMBER_INT(SELF, poweradsr_data_offset);
+    RETURN->v_dur = padsr_obj->getReleaseTime();
+}
+
+CK_DLL_MFUN(poweradsr_getAttackCurve)
+{
+    PowerADSR * padsr_obj = (PowerADSR *) OBJ_MEMBER_INT(SELF, poweradsr_data_offset);
+    RETURN->v_dur = padsr_obj->getAttackCurve();
+}
+
+CK_DLL_MFUN(poweradsr_getDecayCurve)
+{
+    PowerADSR * padsr_obj = (PowerADSR *) OBJ_MEMBER_INT(SELF, poweradsr_data_offset);
+    RETURN->v_dur = padsr_obj->getDecayCurve();
+}
+
+CK_DLL_MFUN(poweradsr_getReleaseCurve)
+{
+    PowerADSR * padsr_obj = (PowerADSR *) OBJ_MEMBER_INT(SELF, poweradsr_data_offset);
+    RETURN->v_dur = padsr_obj->getReleaseCurve();
+}
+
+CK_DLL_MFUN(poweradsr_getValue)
+{
+    PowerADSR * padsr_obj = (PowerADSR *) OBJ_MEMBER_INT(SELF, poweradsr_data_offset);
+    RETURN->v_float = padsr_obj->getValue();
+}
+
+CK_DLL_MFUN(poweradsr_getState)
+{
+    PowerADSR * padsr_obj = (PowerADSR *) OBJ_MEMBER_INT(SELF, poweradsr_data_offset);
+    RETURN->v_int= padsr_obj->getState();
+}

--- a/PowerADSR/poweradsr-feedback-beatings.ck
+++ b/PowerADSR/poweradsr-feedback-beatings.ck
@@ -1,0 +1,52 @@
+// Eric Heep
+// April 3rd, 2017
+// poweradsr-feedback-beatings.ck
+
+// set number of sines and power envs
+5 => int num;
+MagicSine sin[num];
+PowerADSR env[num];
+
+// sound chain
+for (int i; i < num; i++) {
+    sin[i] => env[i] => dac;
+    sin[i].gain(0.25/num);
+}
+
+fun void loopSin(int idx) {
+    dur env_time;
+    float curve;
+    while (true) {
+        Math.random2(1, 2)::second => env_time;
+
+        // curves below 1.0 will be "hill" shaped,
+        // curves above 1.0 will resemble an exponential curve
+        Math.random2f(0.5, 4.0) => curve;
+        sin[idx].freq(Math.random2f(1000, 1100));
+
+        // set all envelope durations
+        env[idx].set(env_time, 1::second, 0.5, env_time);
+
+        // set all envelope power curves
+        env[idx].setCurves(curve, 1.0, 1.0/curve);
+
+        // begins attack phase
+        env[idx].keyOn();
+        env_time => now;
+
+        // begins decay phase
+        1::second => now;
+
+        // begins release phase
+        env[idx].keyOff();
+        env_time => now;
+    }
+}
+
+for (int i; i < num; i++) {
+    spork ~ loopSin(i);
+}
+
+while (true) {
+    1::second => now;
+}

--- a/PowerADSR/poweradsr-help.ck
+++ b/PowerADSR/poweradsr-help.ck
@@ -1,5 +1,8 @@
 // PowerADSR is a power based ADSR envelope that
-// allows separate power curves for each envelope phase
+// allows separate power curves for each envelope phase.
+// In general, curves under 1.0 are sharp, while curves over 1.0 are soft.
+
+// ~ linearEnvelope^curveValue ~
 
 // ~options
 //

--- a/PowerADSR/poweradsr-test.ck
+++ b/PowerADSR/poweradsr-test.ck
@@ -1,0 +1,288 @@
+// Eric Heep
+// April 3rd, 2017
+// power-adsr-test.ck
+
+// unittests to help smooth out some kinks
+
+class PowerADSRTest {
+
+    dur a;
+    dur d;
+    dur r;
+    float s;
+
+    float ac, dc, rc;
+    string errorMessages[0];
+
+    int totalTests, passedTests;
+
+    fun void setTimes(dur _a, dur _d, float _s, dur _r) {
+        _a => a;
+        _d => d;
+        _s => s;
+        _r => r;
+    }
+
+    fun void setCurves(float _ac, float _dc, float _rc) {
+        _ac => ac;
+        _dc => dc;
+        _rc => rc;
+    }
+
+    fun void testAll() {
+        // tests accuracy of state changes
+        testAttackState();
+        testDecayState();
+        testSustainState();
+        testReleaseState();
+        testDoneState();
+
+        // tests to see if the values between states
+        // fall within an acceptable threshold
+        testADValue();
+        testDRValue();
+
+        // tests that state changes happen
+        // at precisely the correct time
+        testALength();
+        testADLength();
+
+        // tests partial envelopes
+        testPartialADValue();
+        testPartialDRValue();
+        testPartialRAValue();
+    }
+
+    fun void testAttackState() {
+        PowerADSR p => blackhole;
+        p.set(a, d, s, r);
+        p.setCurves(ac, dc, rc);
+        p.keyOn();
+
+        p =< blackhole;
+        assert(p.state() == 1, "testAttackState");
+    }
+
+    fun void testDecayState() {
+        PowerADSR p => blackhole;
+        p.set(a, d, s, r);
+        p.setCurves(ac, dc, rc);
+        p.keyOn();
+        a => now;
+
+        p =< blackhole;
+        assert(p.state() == 2, "testDecayState");
+    }
+
+    fun void testSustainState() {
+        PowerADSR p => blackhole;
+        p.set(a, d, s, r);
+        p.setCurves(ac, dc, rc);
+        p.keyOn();
+        a + d => now;
+
+        p =< blackhole;
+        assert(p.state() == 3, "testSustainState");
+    }
+
+    fun void testReleaseState() {
+        PowerADSR p => blackhole;
+        p.set(a, d, s, r);
+        p.setCurves(ac, dc, rc);
+        p.keyOn();
+        a + d => now;
+        p.keyOff();
+
+        p =< blackhole;
+        assert(p.state() == 4, "testReleaseState");
+    }
+
+    fun void testDoneState() {
+        PowerADSR p => blackhole;
+        p.set(a, d, s, r);
+        p.setCurves(ac, dc, rc);
+        p.keyOn();
+        a + d => now;
+        p.keyOff();
+        r => now;
+
+        p =< blackhole;
+        assert(p.state() == 0, "testDoneState");
+    }
+
+    fun void testADValue() {
+        PowerADSR p => blackhole;
+        p.set(a, d, s, r);
+        p.setCurves(ac, dc, rc);
+        p.keyOn();
+        a - 1::samp => now;
+        p.value() => float lastAttackVal;
+        1::samp => now;
+        p.value() => float firstDecayVal;
+
+        p =< blackhole;
+        assertLess(Math.fabs(lastAttackVal - firstDecayVal), 0.001, "testADValue");
+    }
+
+    fun void testDRValue() {
+        PowerADSR p => blackhole;
+        p.set(a, d, s, r);
+        p.setCurves(ac, dc, rc);
+        p.keyOn();
+        (a + d) - 1::samp => now;
+        p.value() => float lastDecayVal;
+        p.keyOff();
+        1::samp => now;
+        p.value() => float firstReleaseVal;
+
+        p =< blackhole;
+        assertLess(Math.fabs(lastDecayVal - firstReleaseVal), 0.001, "testDRValue");
+    }
+
+    fun void testALength() {
+        PowerADSR p => blackhole;
+        p.set(a, d, s, r);
+        p.setCurves(ac, dc, rc);
+        p.keyOn();
+        now => time begin;
+        while (p.state() != 2) {
+            1::samp => now;
+        }
+
+        p =< blackhole;
+        assert(now - begin == a, "testALength");
+    }
+
+    fun void testADLength() {
+        PowerADSR p => blackhole;
+        p.set(a, d, s, r);
+        p.setCurves(ac, dc, rc);
+        p.keyOn();
+        now => time begin;
+        while (p.state() != 3) {
+            1::samp => now;
+        }
+
+        p =< blackhole;
+        assert((now - begin) == (a + d), "testADLength");
+    }
+
+    fun void testPartialADValue() {
+        PowerADSR p => blackhole;
+        p.set(a, d, s, r);
+        p.setCurves(ac, dc, rc);
+        p.keyOn();
+        (a/2.0) - 1::samp => now;
+        p.value() => float lastAttackValue;
+
+        p.keyOff();
+        1::samp => now;
+        p.value() => float firstDecayValue;
+
+        p =< blackhole;
+        assertLess(Math.fabs(lastAttackValue - firstDecayValue), 0.001, "testPartialADValue");
+    }
+
+    fun void testPartialDRValue() {
+        PowerADSR p => blackhole;
+        p.set(a, d, s, r);
+        p.setCurves(ac, dc, rc);
+        p.keyOn();
+        a => now;
+        d/2.0 => now;
+        p.value() => float lastDecayValue;
+        p.keyOff();
+        1::samp => now;
+        p.value() => float firstReleaseValue;
+
+        p =< blackhole;
+        assertLess(Math.fabs(lastDecayValue - firstReleaseValue), 0.001, "testPartialDRValue");
+    }
+
+    fun void testPartialRAValue() {
+        PowerADSR p => blackhole;
+        p.set(a, d, s, r);
+        p.setCurves(ac, dc, rc);
+        p.keyOn();
+        a => now;
+        d => now;
+        p.keyOff();
+        r/2.0 => now;
+        p.value() => float lastReleaseValue;
+        1::samp => now;
+        p.keyOn();
+        1::samp => now;
+        p.value() => float firstAttackValue;
+
+        p =< blackhole;
+        assertLess(Math.fabs(lastReleaseValue - firstAttackValue), 0.015, "testPartialRAValue");
+    }
+
+    fun string results() {
+        chout <= IO.newline();
+        <<< passedTests + "/" + totalTests + " PASSED", "" >>>;
+        if (errorMessages.size() > 0) {
+            for (0 => int i; i < errorMessages.size(); i++) {
+                <<< errorMessages[i], "" >>>;
+            }
+        }
+    }
+
+    fun void update(int bool) {
+        totalTests++;
+        if (bool) {
+            passedTests++;
+        }
+    }
+
+    fun void logError(string error, string fnName) {
+        errorMessages << fnName + " | " + error;
+    }
+
+    fun void assertLess(float a, float b, string fn) {
+        if (a < b) {
+            chout <= ".";
+        } else {
+            chout <= "E";
+            logError(a + " !< " + b, fn);
+        }
+        chout.flush();
+        update(a < b);
+    }
+
+    fun void assert(int bool, string fn) {
+        if (bool) {
+            chout <= ".";
+        } else {
+            cherr <= "E";
+            logError("Does not assert true.", fn);
+        }
+        chout.flush();
+
+        update(bool);
+    }
+}
+
+PowerADSRTest p;
+
+100::ms => dur attack;
+100::ms => dur decay;
+100::ms => dur release;
+
+p.setTimes(attack, decay, 0.5, release);
+p.setCurves(1.0, 1.0, 1.0);
+p.testAll();
+
+p.setTimes(attack, decay, 0.5, release);
+p.setCurves(0.5, 0.5, 0.5);
+p.testAll();
+
+p.setTimes(attack, decay, 0.5, release);
+p.setCurves(2.0, 2.0, 2.0);
+p.testAll();
+
+p.setTimes(attack, decay, 0.5, release);
+p.setCurves(0.5, 2.0, 1.0);
+p.testAll();
+
+p.results();

--- a/PowerADSR/poweradsr-test.ck
+++ b/PowerADSR/poweradsr-test.ck
@@ -29,7 +29,7 @@ class PowerADSRTest {
         _rc => rc;
     }
 
-    fun void testAll() {
+    fun void testEnvelopes() {
         // tests accuracy of state changes
         testAttackState();
         testDecayState();
@@ -51,6 +51,21 @@ class PowerADSRTest {
         testPartialADValue();
         testPartialDRValue();
         testPartialRAValue();
+    }
+
+    fun void testGetters() {
+        // sets and gets durations
+        testGetAttackTime();
+        testGetDecayTime();
+        testGetReleaseTime();
+
+        // sets and gets sustain
+        testGetSustainLevel();
+
+        // sets and gets curves
+        testGetAttackCurve();
+        testGetDecayCurve();
+        testGetReleaseCurve();
     }
 
     fun void testAttackState() {
@@ -218,6 +233,62 @@ class PowerADSRTest {
         assertLess(Math.fabs(lastReleaseValue - firstAttackValue), 0.015, "testPartialRAValue");
     }
 
+    fun void testGetAttackTime() {
+        PowerADSR p => blackhole;
+        Math.random2(2, 9)::second => dur attack;
+        p.attackTime(attack);
+        assert(p.attackTime() == attack, "testGetAttackTime");
+        p =< blackhole;
+    }
+
+    fun void testGetDecayTime() {
+        PowerADSR p => blackhole;
+        Math.random2(2, 9)::second => dur decay;
+        p.decayTime(decay);
+        assert(p.decayTime() == decay, "testGetDecayTime");
+        p =< blackhole;
+    }
+
+    fun void testGetSustainLevel() {
+        PowerADSR p => blackhole;
+        Math.random2f(0.1, 1.0) => float sustain;
+        p.sustainLevel(sustain);
+        assertLess(Math.fabs(p.sustainLevel() - sustain), 0.001, "testGetSustainLevel");
+        p =< blackhole;
+    }
+
+    fun void testGetReleaseTime() {
+        PowerADSR p => blackhole;
+        Math.random2(2, 9)::second => dur release;
+        p.releaseTime(release);
+        assert(p.releaseTime() == release, "testGetReleaseTime");
+        p =< blackhole;
+    }
+
+    fun void testGetAttackCurve() {
+        PowerADSR p => blackhole;
+        Math.random2f(0.5, 2.5) => float attackCurve;
+        p.attackCurve(attackCurve);
+        assertLess(Math.fabs(p.attackCurve() - attackCurve), 0.001, "testGetAttackCurve");
+        p =< blackhole;
+    }
+
+    fun void testGetDecayCurve() {
+        PowerADSR p => blackhole;
+        Math.random2f(0.5, 2.5) => float decayCurve;
+        p.decayCurve(decayCurve);
+        assertLess(Math.fabs(p.decayCurve() - decayCurve), 0.001, "testGetDecayCurve");
+        p =< blackhole;
+    }
+
+    fun void testGetReleaseCurve() {
+        PowerADSR p => blackhole;
+        Math.random2f(0.5, 2.5) => float releaseCurve;
+        p.releaseCurve(releaseCurve);
+        assertLess(Math.fabs(p.releaseCurve() - releaseCurve), 0.001, "testGetReleaseCurve");
+        p =< blackhole;
+    }
+
     fun string results() {
         chout <= IO.newline();
         <<< passedTests + "/" + totalTests + " PASSED", "" >>>;
@@ -271,18 +342,20 @@ PowerADSRTest p;
 
 p.setTimes(attack, decay, 0.5, release);
 p.setCurves(1.0, 1.0, 1.0);
-p.testAll();
+p.testEnvelopes();
 
 p.setTimes(attack, decay, 0.5, release);
 p.setCurves(0.5, 0.5, 0.5);
-p.testAll();
+p.testEnvelopes();
 
 p.setTimes(attack, decay, 0.5, release);
 p.setCurves(2.0, 2.0, 2.0);
-p.testAll();
+p.testEnvelopes();
 
 p.setTimes(attack, decay, 0.5, release);
 p.setCurves(0.5, 2.0, 1.0);
-p.testAll();
+p.testEnvelopes();
+
+p.testGetters();
 
 p.results();


### PR DESCRIPTION
Rewrote PowerADSR to get rid of a few bugs, it now follows the standard envelope state model. This brings with it the ability to retrieve the state of the envelope. Also added get functions for durations, curves, and the current value of the envelope.

`.state()`, `.attackTime()`, `.decayTime()`, `.sustainLevel()`, `releaseTime()`, `.attackCurve()`, `.decayCurve()`, `.sustainCurve()`, `.value()`, 

Updated `power-adsr-help.ck` to actually be helpful, and some unit tests so it's not so buggy this time.