### PR TITLE
Remove (deprecated) register keywords

### DIFF
--- a/Elliptic/ellipse.c
+++ b/Elliptic/ellipse.c
@@ -63,9 +63,9 @@ ellpset(EllSect es[], float *xnorm)
 float
 ellipse(float sig, int nsects, EllSect es[], float xnorm)
 {  
-  register int     i;
-  register float   y0;
-  register EllSect *s;
+  /* register */ int     i;
+  /* register */ float   y0;
+  /* register */ EllSect *s;
   
   for (i = 0; i < nsects; i++) {
     s = &es[i];

--- a/Mesh2D/Stk.cpp
+++ b/Mesh2D/Stk.cpp
@@ -125,7 +125,7 @@ void Stk :: setRawwavePath( std::string path )
 
 void Stk :: swap16(unsigned char *ptr)
 {
-  register unsigned char val;
+  /* register */ unsigned char val;
 
   // Swap 1st and 2nd bytes
   val = *(ptr);
@@ -135,7 +135,7 @@ void Stk :: swap16(unsigned char *ptr)
 
 void Stk :: swap32(unsigned char *ptr)
 {
-  register unsigned char val;
+  /* register */ unsigned char val;
 
   // Swap 1st and 4th bytes
   val = *(ptr);
@@ -151,7 +151,7 @@ void Stk :: swap32(unsigned char *ptr)
 
 void Stk :: swap64(unsigned char *ptr)
 {
-  register unsigned char val;
+  /* register */ unsigned char val;
 
   // Swap 1st and 8th bytes
   val = *(ptr);


### PR DESCRIPTION
These are fully deprecated in c++17 and it will be sad if you use them