### PR TITLE
Fix WinFuncEnv's tukey releaseWindow

### DIFF
--- a/WinFuncEnv/WinFuncEnv.cpp
+++ b/WinFuncEnv/WinFuncEnv.cpp
@@ -389,6 +389,7 @@ public:
         pi = M_PI;
     }
 
+    // Reference: https://www.mathworks.com/help/signal/ref/tukeywin.html
     float attackWindow (int n, int attack) {
         if( n == 0 )
         {
@@ -405,11 +406,11 @@ public:
         {
         }
 
-        if ( n < a * release ) {
+        if ( n < release - a * release ) {
             return 1.0;
         }
         else {
-            return 0.5 * (1.0 + cos(pi * ((2 * n)/(a * release * 2.0) - 2.0/a + 1.0)));
+            return 0.5 * (1.0 + cos(pi * (n / (a * release) + (1 / a) - (2.0 / a) + 1.0)));
         }
     }
 private:


### PR DESCRIPTION
WinFuncEnv's tukey envelope's math was borked on the `keyOff` function. This was causing sudden dips and other weird behaviors when it stopped outputting 1s and started calculating the cosine-tapering.

Here's the original envelope (at a ratio of 0.7):
![image](https://github.com/ccrma/chugins/assets/6963603/ba84c443-f51c-488a-a4e5-6d51ff2e89c6)

Here's the fixed version:
![image](https://github.com/ccrma/chugins/assets/6963603/8cf01263-a439-451a-9c4a-c9aa06ccb5ce)
