### PR TITLE
GitHub Action for WarpBuf on macOS arm64

### DIFF
--- a/.github/workflows/WarpBuf.yml
+++ b/.github/workflows/WarpBuf.yml
@@ -21,15 +21,25 @@ jobs:
         include:
           - name: ubuntu-x86_64
             os: ubuntu-20.04
+            CMAKE_OSX_ARCHITECTURES: "x86_64"
+            os-simple: linux
           - name: macos-x86_64
-            os: macos-11
+            os: macos-12
+            CMAKE_OSX_ARCHITECTURES: "x86_64"
+            os-simple: mac
+          - name: macos-arm64
+            os: macos-12
+            CMAKE_OSX_ARCHITECTURES: "arm64"
+            os-simple: mac
           - name: win64
             os: windows-2022
+            CMAKE_OSX_ARCHITECTURES: "x86_64"
+            os-simple: win
 
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -40,8 +50,30 @@ jobs:
         libflac-dev libogg-dev libtool libvorbis-dev libopus-dev libmp3lame-dev \
         libmpg123-dev pkg-config python
 
-    - name: Install dependencies macOS
-      if: startsWith(matrix.os, 'macos')
+    - name: Brew dependencies macOS (arm64)
+      if: ${{ endsWith( matrix.name, 'macos-arm64') }}
+      run: |
+        brew update
+        PACKAGES=(flac libogg libtool libvorbis opus mpg123 lame)
+        DEPS=($(brew deps --union --topological $(echo $PACKAGES) | tr '\n' ' '))
+        PACKAGES=("${DEPS[@]}" "${PACKAGES[@]}")
+        export HOMEBREW_NO_INSTALL_CLEANUP=1
+        export HOMEBREW_NO_INSTALL_UPGRADE=1
+        export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
+        for PACKAGE in "${PACKAGES[@]}"
+        do
+          echo "Fetching bottle: $PACKAGE"
+          response=$(brew fetch --bottle-tag=arm64_monterey $PACKAGE 2>&1)
+          package_path=$(echo $response | sed -n 's/.*\:\ \(.*\.tar\.gz\).*/\1/p')
+          package_path=$(echo "$package_path" | xargs)
+          echo "Package Path: $package_path"
+          brew reinstall --verbose --force-bottle "$package_path" || true
+        done
+
+        brew uninstall --ignore-dependencies curl git || true
+
+    - name: Brew dependencies macOS (x86)
+      if: ${{ endsWith( matrix.name, 'macos-x86_64') }}
       run: |
         brew install autoconf autogen automake flac libogg libtool libvorbis opus mpg123 pkg-config
 
@@ -57,18 +89,18 @@ jobs:
       if: startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu')
       run: |
         cd WarpBuf/thirdparty/libsndfile
-        cmake -Bbuild -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_CXX_FLAGS="-fPIC" -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX="./install"
+        cmake -Bbuild -DCMAKE_OSX_ARCHITECTURES=${{ matrix.CMAKE_OSX_ARCHITECTURES }} -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_CXX_FLAGS="-fPIC" -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX="./install"
         cmake --build build --config Release
         cmake --build build --target install
 
     - name: Build WarpBuf Release
       run: |
         cd WarpBuf
-        cmake -Bbuild -DCMAKE_VERBOSE_MAKEFILE=ON
+        cmake -Bbuild -DCMAKE_OSX_ARCHITECTURES=${{ matrix.CMAKE_OSX_ARCHITECTURES }} -DCMAKE_VERBOSE_MAKEFILE=ON
         cmake --build build --config Release
         cmake --build build --config Release --target install
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: warpbuf-${{ matrix.name }}.zip
         path: "WarpBuf/package/warpbuf-${{ env.WARPBUF_VERSION }}"

--- a/WarpBuf/CMakeLists.txt
+++ b/WarpBuf/CMakeLists.txt
@@ -149,7 +149,6 @@ else()
     pkg_check_modules(OPUS REQUIRED IMPORTED_TARGET opus)
     pkg_check_modules(MPG123 REQUIRED IMPORTED_TARGET libmpg123)
     if(APPLE)
-    execute_process(COMMAND find /usr/local/Cellar/lame -name libmp3lame.a OUTPUT_VARIABLE SNDFILE_STATIC_LIBS OUTPUT_STRIP_TRAILING_WHITESPACE)
     list(POP_BACK PKG_CONFIG_EXECUTABLE)  # undo the append above
     endif()
     target_link_libraries (${PROJECT_NAME} PRIVATE PkgConfig::SNDFILE PkgConfig::FLAC PkgConfig::VORBIS PkgConfig::OGG PkgConfig::OPUS PkgConfig::MPG123 ${SNDFILE_STATIC_LIBS})

--- a/WarpBuf/src/WarpBufChuginDLL.cpp
+++ b/WarpBuf/src/WarpBufChuginDLL.cpp
@@ -34,6 +34,20 @@ CK_DLL_TICKF(warpbuf_tick);
 t_CKINT warpbuf_data_offset = 0;
 
 //-----------------------------------------------------------------------------
+// info function: ChucK calls this when loading/probing the chugin
+// NOTE: please customize these info fields below; they will be used for
+// chugins loading, probing, and package management and documentation
+//-----------------------------------------------------------------------------
+CK_DLL_INFO( WarpBuf )
+{
+    QUERY->setinfo( QUERY, CHUGIN_INFO_CHUGIN_VERSION, "v0.0.1" );
+    QUERY->setinfo( QUERY, CHUGIN_INFO_AUTHORS, "David Braun" );
+    QUERY->setinfo( QUERY, CHUGIN_INFO_DESCRIPTION, "A chugin which can timestretch and pitch-bend a sound buffer, thanks to the Rubber Band Library." );
+    QUERY->setinfo( QUERY, CHUGIN_INFO_URL, "https://github.com/ccrma/chugins" );
+    QUERY->setinfo( QUERY, CHUGIN_INFO_EMAIL, "braun@ccrma.stanford.edu" );
+}
+
+//-----------------------------------------------------------------------------
 // query function: chuck calls this when loading the Chugin
 //-----------------------------------------------------------------------------
 CK_DLL_QUERY(WarpBuf)


### PR DESCRIPTION
This is a minimal update to get a working GitHub action for macOS arm64. I tested the arm64 build from [here](https://github.com/DBraun/chugins/actions/runs/8668291687) and it worked fine, somewhat unexpectedly since I thought macOS gatekeeper would ruin it.

A later PR can switch everything to a Makefile instead of the current shell script for building.