### PR TITLE
update FluidSynth.cpp to APIv10.1, fixed segfault in FluidSynth-play.ck example

### DIFF
--- a/FluidSynth/FluidSynth-play.ck
+++ b/FluidSynth/FluidSynth-play.ck
@@ -18,6 +18,11 @@ if(!min.open(filename))
 
 chout <= filename <= ": " <= min.numTracks() <= " tracks\n";
 
+FluidSynth m => rev;
+m => dac;
+0.91 => m.gain;
+m.open(sfont);
+
 int done;
 
 for(int t; t < min.numTracks(); t++)
@@ -32,10 +37,7 @@ minute => now;
 
 fun void track(int t)
 {
-    FluidSynth m => rev;
-    m => dac;
-    0.91 => m.gain;
-    m.open(sfont);
+    
     
     while(min.read(msg, t))
     {

--- a/FluidSynth/FluidSynth.cpp
+++ b/FluidSynth/FluidSynth.cpp
@@ -111,7 +111,14 @@ public:
             allChans = true;
             chan = 0;
         }
-        fluid_synth_activate_key_tuning(m_synth, 0, chan, "", (double *) tuning, false);
+
+        double * tuningArr;
+        tuningArr = new double[api->object->array_float_size(tuning)];
+        for (int i = 0; i < api->object->array_float_size(tuning); i++) {
+            tuningArr[i] = (double) api->object->array_float_get_idx(tuning,i);
+        }
+
+        fluid_synth_activate_key_tuning(m_synth, 0, chan, "", tuningArr, false);
         
         if (allChans) {
             for (chan = 0 ; chan<16 ; chan++) {
@@ -129,7 +136,14 @@ public:
             allChans = true;
             chan = 0;
         }
-        fluid_synth_activate_octave_tuning(m_synth, 0, chan, "", (double *) tuning, false);
+
+        double * tuningArr;
+        tuningArr = new double[api->object->array_float_size(tuning)];
+        for (int i = 0; i < api->object->array_float_size(tuning); i++) {
+            tuningArr[i] = (double) api->object->array_float_get_idx(tuning,i);
+        }  
+
+        fluid_synth_activate_octave_tuning(m_synth, 0, chan, "", tuningArr, false);
         
         if (allChans) {
             for (chan = 0 ; chan<16 ; chan++) {
@@ -168,8 +182,15 @@ public:
         for (int i = 0; i < api->object->array_int_size(noteNums); i++) {
             noteNumArr[i] = (int) api->object->array_int_get_idx(noteNums,i);
         }
+
+        double * pitchesArr;
+        pitchesArr = new double[api->object->array_float_size(pitches)];
+        for (int i = 0; i < api->object->array_float_size(pitches); i++) {
+            pitchesArr[i] = (double) api->object->array_float_get_idx(pitches,i);
+        }
+
         fluid_synth_tune_notes(m_synth, 0, chan, api->object->array_float_size(pitches),
-                               noteNumArr, (double *) pitches, false);
+                               noteNumArr, pitchesArr, false);
 
         delete [] noteNumArr;
     }

--- a/FluidSynth/makefile.mac
+++ b/FluidSynth/makefile.mac
@@ -22,7 +22,7 @@ ARCHS?=
 ARCHOPTS=$(addprefix -arch ,$(ARCHS))
 
 # compiler flags
-FLAGS+=-mmacosx-version-min=10.9 -I$(CK_SRC_PATH) $(ARCHOPTS) -fPIC -I$(FLUIDSYNTH_PREFIX)/include
+FLAGS+=-mmacosx-version-min=10.9 -I$(CK_SRC_PATH) $(ARCHOPTS) -I$(FLUIDSYNTH_PREFIX)/include
 # linker flags
 LDFLAGS+=-mmacosx-version-min=10.9 -shared -lc++ $(ARCHOPTS) -L$(FLUIDSYNTH_PREFIX)/lib -lfluidsynth
 

--- a/FluidSynth/makefile.mac
+++ b/FluidSynth/makefile.mac
@@ -1,11 +1,32 @@
+#-----------------------------------
+# makefile.mac
+# macOS-specific build configuration
+#-----------------------------------
 
-ARCHS?=x86_64 arm64
+FLUIDSYNTH_PREFIX=/usr/local
+
+# to build for the native architecture: (leave blank)
+# ARCHS?=
+#
+# to build for intel:
+# ARCHS?=x86_64
+#
+# to build for apple silicon:
+# ARCHS?=arm64
+#
+# to build a universal=binary chugin:
+# ARCHS?=x86_64 arm64
+ARCHS?=
+
+# construct compiler option string
 ARCHOPTS=$(addprefix -arch ,$(ARCHS))
 
-FLUIDSYNTH_PREFIX=/opt/local
+# compiler flags
+FLAGS+=-mmacosx-version-min=10.9 -I$(CK_SRC_PATH) $(ARCHOPTS) -fPIC -I$(FLUIDSYNTH_PREFIX)/include
+# linker flags
+LDFLAGS+=-mmacosx-version-min=10.9 -shared -lc++ $(ARCHOPTS) -L$(FLUIDSYNTH_PREFIX)/lib -lfluidsynth
 
-FLAGS+=-mmacosx-version-min=10.9 -I$(CK_SRC_PATH) $(ARCHOPTS) -I$(FLUIDSYNTH_PREFIX)/include
-LDFLAGS+=-mmacosx-version-min=10.9 -shared -lc++ $(ARCHOPTS) -L$(FLUIDSYNTH_PREFIX)/lib
-
-LD=clang++
+# which C++ compiler
 CXX=clang++
+# which linker to user
+LD=clang++


### PR DESCRIPTION
This commit:
1. Updates FluidSynth.cpp so that it is compatible with the API version 10.1
2. Updates the makefile.mac to point to a FluidSynth installation (required to build this chugin)
3. Fixes a segfault in FluidSynth-play.ck by moving the FluidSynth initialization outside of a function